### PR TITLE
Small improvements

### DIFF
--- a/Demo/TestWPF/Settings/DisplaySettings.cs
+++ b/Demo/TestWPF/Settings/DisplaySettings.cs
@@ -29,8 +29,9 @@ namespace TestWPF.Settings
 
         protected virtual void OnPropertyChanged(string propertyName)
         {
-            if (PropertyChanged != null)
-                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+            var handler = PropertyChanged;
+            if (handler != null)
+                handler(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Demo/TestWPF/Settings/DisplaySettings.cs
+++ b/Demo/TestWPF/Settings/DisplaySettings.cs
@@ -31,8 +31,7 @@ namespace TestWPF.Settings
         protected virtual void OnPropertyChanged([CallerMemberName]string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null)
-                handler(this, new PropertyChangedEventArgs(propertyName));
+            handler?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Demo/TestWPF/Settings/DisplaySettings.cs
+++ b/Demo/TestWPF/Settings/DisplaySettings.cs
@@ -30,8 +30,7 @@ namespace TestWPF.Settings
 
         protected virtual void OnPropertyChanged([CallerMemberName]string propertyName = null)
         {
-            var handler = PropertyChanged;
-            handler?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Demo/TestWPF/Settings/DisplaySettings.cs
+++ b/Demo/TestWPF/Settings/DisplaySettings.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.ComponentModel;
 using System.Windows.Media;
+using System.Runtime.CompilerServices;
 
 namespace TestWPF.Settings
 {
@@ -14,20 +15,20 @@ namespace TestWPF.Settings
         public FontFamily Font
         {
             get { return _font; }
-            set { _font = value; OnPropertyChanged("Font"); }
+            set { _font = value; OnPropertyChanged(); }
         }
 
         private decimal _fontSize = 15;
         public decimal FontSize
         {
             get { return _fontSize; }
-            set { _fontSize = value; OnPropertyChanged("FontSize"); }
+            set { _fontSize = value; OnPropertyChanged(); }
         }
 
         [field: NonSerialized]
         public event PropertyChangedEventHandler PropertyChanged;
 
-        protected virtual void OnPropertyChanged(string propertyName)
+        protected virtual void OnPropertyChanged([CallerMemberName]string propertyName = null)
         {
             var handler = PropertyChanged;
             if (handler != null)

--- a/Demo/TestWPFWithUnity/Settings/DisplaySettings.cs
+++ b/Demo/TestWPFWithUnity/Settings/DisplaySettings.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.ComponentModel;
 using System.Windows.Media;
+using System.Runtime.CompilerServices;
 
 namespace TestWPFWithUnity.Settings
 {
@@ -17,20 +18,20 @@ namespace TestWPFWithUnity.Settings
         public FontFamily Font
         {
             get { return _font; }
-            set { _font = value; OnPropertyChanged("Font"); }
+            set { _font = value; OnPropertyChanged(); }
         }
 
         private decimal _fontSize = 15;
         public decimal FontSize
         {
             get { return _fontSize; }
-            set { _fontSize = value; OnPropertyChanged("FontSize"); }
+            set { _fontSize = value; OnPropertyChanged(); }
         }
 
         [field: NonSerialized]
         public event PropertyChangedEventHandler PropertyChanged;
 
-        protected virtual void OnPropertyChanged(string propertyName)
+        protected virtual void OnPropertyChanged([CallerMemberName]string propertyName = null)
         {
             var handler = PropertyChanged;
             if (handler != null)

--- a/Demo/TestWPFWithUnity/Settings/DisplaySettings.cs
+++ b/Demo/TestWPFWithUnity/Settings/DisplaySettings.cs
@@ -32,8 +32,9 @@ namespace TestWPFWithUnity.Settings
 
         protected virtual void OnPropertyChanged(string propertyName)
         {
-            if (PropertyChanged != null)
-                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+            var handler = PropertyChanged;
+            if (handler != null)
+                handler(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Demo/TestWPFWithUnity/Settings/DisplaySettings.cs
+++ b/Demo/TestWPFWithUnity/Settings/DisplaySettings.cs
@@ -34,8 +34,7 @@ namespace TestWPFWithUnity.Settings
         protected virtual void OnPropertyChanged([CallerMemberName]string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null)
-                handler(this, new PropertyChangedEventArgs(propertyName));
+            handler?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Demo/TestWPFWithUnity/Settings/DisplaySettings.cs
+++ b/Demo/TestWPFWithUnity/Settings/DisplaySettings.cs
@@ -33,8 +33,7 @@ namespace TestWPFWithUnity.Settings
 
         protected virtual void OnPropertyChanged([CallerMemberName]string propertyName = null)
         {
-            var handler = PropertyChanged;
-            handler?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Jot/Configuration/TrackingConfiguration.cs
+++ b/Jot/Configuration/TrackingConfiguration.cs
@@ -24,10 +24,11 @@ namespace Jot.Configuration
         public event EventHandler<TrackingOperationEventArgs> ApplyingProperty;
         private bool OnApplyingState(string property)
         {
-            if (ApplyingProperty != null)
+            var handler = ApplyingProperty;
+            if (handler != null)
             {
                 TrackingOperationEventArgs args = new TrackingOperationEventArgs(this, property);
-                ApplyingProperty(this, args);
+                handler(this, args);
                 return !args.Cancel;
             }
             else
@@ -37,17 +38,19 @@ namespace Jot.Configuration
         public event EventHandler StateApplied;
         private void OnStateApplied()
         {
-            if (StateApplied != null)
-                StateApplied(this, EventArgs.Empty);
+            var handler = StateApplied;
+            if (handler != null)
+                handler(this, EventArgs.Empty);
         }
 
         public event EventHandler<TrackingOperationEventArgs> PersistingProperty;
         private bool OnPersistingState(string property)
         {
-            if (PersistingProperty != null)
+            var handler = PersistingProperty;
+            if (handler != null)
             {
                 TrackingOperationEventArgs args = new TrackingOperationEventArgs(this, property);
-                PersistingProperty(this, args);
+                handler(this, args);
                 return !args.Cancel;
             }
             return true;
@@ -56,8 +59,9 @@ namespace Jot.Configuration
         public event EventHandler StatePersisted;
         private void OnStatePersisted()
         {
-            if (StatePersisted != null)
-                StatePersisted(this, EventArgs.Empty);
+            var handler = StatePersisted;
+            if (handler != null)
+                handler(this, EventArgs.Empty);
         }
         #endregion
 

--- a/Jot/Configuration/TrackingConfiguration.cs
+++ b/Jot/Configuration/TrackingConfiguration.cs
@@ -39,8 +39,7 @@ namespace Jot.Configuration
         private void OnStateApplied()
         {
             var handler = StateApplied;
-            if (handler != null)
-                handler(this, EventArgs.Empty);
+            handler?.Invoke(this, EventArgs.Empty);
         }
 
         public event EventHandler<TrackingOperationEventArgs> PersistingProperty;
@@ -60,8 +59,7 @@ namespace Jot.Configuration
         private void OnStatePersisted()
         {
             var handler = StatePersisted;
-            if (handler != null)
-                handler(this, EventArgs.Empty);
+            handler?.Invoke(this, EventArgs.Empty);
         }
         #endregion
 

--- a/Jot/Configuration/TrackingConfiguration.cs
+++ b/Jot/Configuration/TrackingConfiguration.cs
@@ -38,8 +38,7 @@ namespace Jot.Configuration
         public event EventHandler StateApplied;
         private void OnStateApplied()
         {
-            var handler = StateApplied;
-            handler?.Invoke(this, EventArgs.Empty);
+            StateApplied?.Invoke(this, EventArgs.Empty);
         }
 
         public event EventHandler<TrackingOperationEventArgs> PersistingProperty;
@@ -58,8 +57,7 @@ namespace Jot.Configuration
         public event EventHandler StatePersisted;
         private void OnStatePersisted()
         {
-            var handler = StatePersisted;
-            handler?.Invoke(this, EventArgs.Empty);
+            StatePersisted?.Invoke(this, EventArgs.Empty);
         }
         #endregion
 

--- a/Jot/Triggers/DesktopPersistTrigger.cs
+++ b/Jot/Triggers/DesktopPersistTrigger.cs
@@ -19,8 +19,7 @@ namespace Jot.Triggers
         private void OnApplicationClosing()
         {
             var handler = PersistRequired;
-            if (handler != null)
-                handler(this, EventArgs.Empty);
+            handler?.Invoke(this, EventArgs.Empty);
         }
 
         public event EventHandler PersistRequired;

--- a/Jot/Triggers/DesktopPersistTrigger.cs
+++ b/Jot/Triggers/DesktopPersistTrigger.cs
@@ -18,8 +18,7 @@ namespace Jot.Triggers
 
         private void OnApplicationClosing()
         {
-            var handler = PersistRequired;
-            handler?.Invoke(this, EventArgs.Empty);
+            PersistRequired?.Invoke(this, EventArgs.Empty);
         }
 
         public event EventHandler PersistRequired;

--- a/Jot/Triggers/DesktopPersistTrigger.cs
+++ b/Jot/Triggers/DesktopPersistTrigger.cs
@@ -18,8 +18,9 @@ namespace Jot.Triggers
 
         private void OnApplicationClosing()
         {
-            if (PersistRequired != null)
-                PersistRequired(this, EventArgs.Empty);
+            var handler = PersistRequired;
+            if (handler != null)
+                handler(this, EventArgs.Empty);
         }
 
         public event EventHandler PersistRequired;


### PR DESCRIPTION
I've changed a few event calls to ensure that they are thread safe and I've also added a nicer way of invoking `OnPropertyChanged`. This will prevent you from having to provide the name of the property in the parameters as the `[CallerMemberName]` attribute will automatically pick it up.
