### PR TITLE
Added possibility to select if IStore should be named after Key only.

### DIFF
--- a/Jot/Jot.csproj
+++ b/Jot/Jot.csproj
@@ -74,6 +74,7 @@
     <Compile Include="CustomInitializers\FormConfigurationInitializer.cs" />
     <Compile Include="IConfigurationInitializer.cs" />
     <Compile Include="CustomInitializers\WindowConfigurationInitializer.cs" />
+    <Compile Include="Schemes\NamingScheme.cs" />
     <Compile Include="Storage\IStoreFactory.cs" />
     <Compile Include="Storage\JsonFileStoreFactory.cs" />
     <Compile Include="Storage\Stores\JsonFileStore.cs" />

--- a/Jot/Schemes/NamingScheme.cs
+++ b/Jot/Schemes/NamingScheme.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jot
+{
+    /// <summary>
+    /// Naming scheme for Storaname (defines filename format, where is the configuration stored).
+    /// </summary>
+    public enum NamingScheme
+    {
+        TypeNameAndKey,
+        KeyOnly,
+    }
+}

--- a/Jot/Schemes/NamingScheme.cs
+++ b/Jot/Schemes/NamingScheme.cs
@@ -11,7 +11,13 @@ namespace Jot
     /// </summary>
     public enum NamingScheme
     {
+        /// <summary>
+        /// {TypeName}_{key}
+        /// </summary>
         TypeNameAndKey,
+        /// <summary>
+        /// {key}
+        /// </summary>
         KeyOnly,
     }
 }

--- a/Jot/TrackingConfiguration.cs
+++ b/Jot/TrackingConfiguration.cs
@@ -40,16 +40,8 @@ namespace Jot
         public string Key { get; set; }
 
         /// <summary>
-        /// The identity of the target. This severs to identify which stored data belongs to which object. 
-        /// Defines format of store name.
+        /// Defines format of store name. Default value is TypeNameAndKey. In that case the storename is "{typename}_{key}".
         /// </summary>
-        public enum NamingScheme
-        {
-            TypeNameAndKey, //predefined
-            KeyAndTypeName,
-            KeyOnly,
-            TypeNameOnly
-        }
         public NamingScheme StoreNamingScheme { get; set; } = NamingScheme.TypeNameAndKey;
 
         /// <summary>
@@ -392,14 +384,14 @@ namespace Jot
         private IStore InitStore()
         {
             object target = TargetReference.Target;
-            //use the object type plus the key to identify the object store
-            string storeName = target.GetType().Name;
+
+            //use the object type plus the key to identify the object store based on NamingScheme
+            string storeName;            
             switch (StoreNamingScheme)
             {
-                case NamingScheme.TypeNameAndKey: storeName = string.Format("{0}_{1}", target.GetType().Name, Key); break;
                 case NamingScheme.KeyOnly: storeName = Key; break;
-                case NamingScheme.KeyAndTypeName: storeName = string.Format("{0}_{1}", Key, target.GetType().Name); break;
-                case NamingScheme.TypeNameOnly: storeName = target.GetType().Name; break;
+                //default is reserved for NamingScheme.TypeNameAndKey
+                default: storeName = Key == null ? target.GetType().Name : string.Format("{0}_{1}", target.GetType().Name, Key); break;
             }
             return StateTracker.StoreFactory.CreateStoreForObject(storeName);
         }

--- a/Jot/TrackingConfiguration.cs
+++ b/Jot/TrackingConfiguration.cs
@@ -209,6 +209,7 @@ namespace Jot
         /// to what object. Otherwise, they will use the same data which is usually not what you want.
         /// </summary>
         /// <param name="key"></param>
+        /// <param name="storeNamingScheme"></param>
         /// <returns></returns>
         public TrackingConfiguration IdentifyAs(string key, NamingScheme storeNamingScheme = NamingScheme.TypeNameAndKey)
         {

--- a/Jot/TrackingConfiguration.cs
+++ b/Jot/TrackingConfiguration.cs
@@ -40,6 +40,12 @@ namespace Jot
         public string Key { get; set; }
 
         /// <summary>
+        /// The identity of the target. This severs to identify which stored data belongs to which object. If not specified,
+        /// check out the Key definition. If specified the Key is used to indetification. In case Key is not defined, this parameter is ignored.
+        /// </summary>
+        public bool IncludeClassName { get; set; } = true;
+
+        /// <summary>
         /// A dictioanary containing the tracked properties.
         /// </summary>
         public Dictionary<string, TrackedPropertyInfo> TrackedProperties { get; set; } = new Dictionary<string, TrackedPropertyInfo>();
@@ -205,12 +211,14 @@ namespace Jot
         /// </summary>
         /// <param name="key"></param>
         /// <returns></returns>
-        public TrackingConfiguration IdentifyAs(string key)
+        public TrackingConfiguration IdentifyAs(string key, bool includeClassName = true)
         {
             if (TargetStore != null)
                 throw new InvalidOperationException("Can't set key after TargetStore has been set (which happens the first time Apply() or Persist() is called).");
 
             Key = key;
+            IncludeClassName = includeClassName;
+            
             return this;
         }
 
@@ -378,7 +386,7 @@ namespace Jot
         {
             object target = TargetReference.Target;
             //use the object type plus the key to identify the object store
-            string storeName = Key == null ? target.GetType().Name : string.Format("{0}_{1}", target.GetType().Name, Key);
+            string storeName = Key == null ? target.GetType().Name : IncludeClassName == true ? string.Format("{0}_{1}", target.GetType().Name, Key) : Key;
             return StateTracker.StoreFactory.CreateStoreForObject(storeName);
         }
 


### PR DESCRIPTION
Hi, I don´t like naming limitation, where the final filename is based on [classname]_[Key]. I consider it more comfortable to declare final filename with IdentifyAs method. (For example, in case of obfuscation there would be weird file names.)

As you can see in changes, I preserved compatibility = you can still: 
`Tracker.Configure([instance of class]).IdentifyAs("general").Apply();`
If you want to have saved settings in "general.json" file: 
`Tracker.Configure([instance of class]).IdentifyAs("general", false).Apply();`
Where **false** mean **do not include** class name. 