### PR TITLE
Increase availability to .NET Core

### DIFF
--- a/Jot/Jot.csproj
+++ b/Jot/Jot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Version>2.1.4</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Antonio Nakic-Alfirevic</Authors>


### PR DESCRIPTION
Remove the requirement for .net45 in target framework since it's, from what I can see, not used in any case, all 27 tests are working and I can have a state in both WPF and WinForms. It also makes it more accessible to .Net Core since it's already .netstandard.