### PR TITLE
Fix anakic/Jot#48 - Provide access to Tracker property in TrackingConfiguration<T> class

### DIFF
--- a/Jot/Configuration/TrackingConfiguration.cs
+++ b/Jot/Configuration/TrackingConfiguration.cs
@@ -28,7 +28,7 @@ namespace Jot.Configuration
         /// <summary>
         /// The StateTracker that owns this tracking configuration.
         /// </summary>
-        public Tracker Tracker { get; }
+        public virtual Tracker Tracker { get; }
 
         /// <summary>
         /// A dictionary containing the tracked properties.

--- a/Jot/Configuration/TrackingConfigurationGeneric.cs
+++ b/Jot/Configuration/TrackingConfigurationGeneric.cs
@@ -22,6 +22,8 @@ namespace Jot.Configuration
     {
         private readonly TrackingConfiguration inner;
 
+        public override Tracker Tracker => inner.Tracker;
+
         internal TrackingConfiguration(TrackingConfiguration inner)
         {
             this.inner = inner;


### PR DESCRIPTION
I thought of two solutions...
 - either `inner.Tracker` could be set to the `TrackingConfiguration<T>`'s `Tracker` property in the constructor
 - or the `TrackingConfiguration<T>`'s `Tracker` property could always return `inner.Tracker`

In terms of required changes, either one requires the base `Tracker` property to be modified (in one case, it must be virtual, and in the other, it must have a protected setter).

I settled on the second was better for maintainability and matching the rest of the pattern in the `TrackingConfiguration<T>` to return `inner` methods/properties.