### PR TITLE
Add AvaloniaUI example to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ public MainWindow()
 #if DEBUG
     this.AttachDevTools();
 #endif
-    var trackerNamespace = string.Join("|", Screens.All.Select(s => s.WorkingArea.Size.ToString()));
-    trackerNamespace += "||" + Environment.ProcessPath?.Replace("/", "|").Replace("\\", "|"); // <-- Add this if you want multiple copies of the same app to have different configurations.
+    var trackerNamespace = string.Join("_", Screens.All.Select(s => s.WorkingArea.Size.ToString()));
+    trackerNamespace += "__" + Environment.ProcessPath?.Replace("/", "_").Replace("\\", "_"); // <-- Add this if you want multiple copies of the same app to have different configurations.
     Program.Tracker.Configure<Window>()
         .Id(w => w.Name, trackerNamespace)
         .Properties(w => new { w.WindowState, w.Position, w.Width, w.Height })

--- a/README.md
+++ b/README.md
@@ -158,7 +158,11 @@ protected override void OnLoad(EventArgs e)
 
 #### Avalonia UI
 
-For [Avalonia UI](https://avaloniaui.net/) it is similar to WPF except that the screen information is available from the Window class instead of being static.
+For [Avalonia UI](https://avaloniaui.net/) it is similar to WPF with some diferences:  
+- The screen information is available from the Window class instead of being static.
+- Closing the app while being minimized would open the app next time also minimized if we don't check for that during window load.
+- When the app is minimized it reports a negative position instead of the position it would have if not minimized,
+  so we need to check for negative position values during window load to prevent setting the window out of reach.
 
 ``` C#
 // in the Program.cs
@@ -172,6 +176,7 @@ public MainWindow()
 #if DEBUG
     this.AttachDevTools();
 #endif
+    var initialPosition = this.Position;
     var trackerNamespace = string.Join("_", Screens.All.Select(s => s.WorkingArea.Size.ToString()));
     trackerNamespace += "__" + Environment.ProcessPath?.Replace("/", "_").Replace("\\", "_"); // <-- Add this if you want multiple copies of the same app to have different configurations.
     Program.Tracker.Configure<Window>()
@@ -180,6 +185,15 @@ public MainWindow()
         .PersistOn(nameof(Window.Closing))
         .StopTrackingOn(nameof(Window.Closing));
     Program.Tracker.Track(this);
+
+    if (this.WindowState == WindowState.Minimized)
+    {
+        this.WindowState = WindowState.Normal;
+    }
+    if (this.Position.X < 0 || this.Position.Y < 0)
+    {
+        this.Position = initialPosition;
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ public MainWindow()
     this.AttachDevTools();
 #endif
     var trackerNamespace = string.Join("|", Screens.All.Select(s => s.WorkingArea.Size.ToString()));
-    var trackerNamespace += Environment.ProcessPath; // <-- Add this if you want multiple copies of the same app to have different configurations.
+    var trackerNamespace += "||" + Environment.ProcessPath.Replace("/", "|").Replace("\\", "|"); // <-- Add this if you want multiple copies of the same app to have different configurations.
     Program.Tracker.Configure<Window>()
         .Id(w => w.Name, trackerNamespace)
         .Properties(w => new { w.WindowState, w.Position, w.Width, w.Height })

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ public MainWindow()
     this.AttachDevTools();
 #endif
     var trackerNamespace = string.Join("|", Screens.All.Select(s => s.WorkingArea.Size.ToString()));
-    var trackerNamespace += "||" + Environment.ProcessPath.Replace("/", "|").Replace("\\", "|"); // <-- Add this if you want multiple copies of the same app to have different configurations.
+    trackerNamespace += "||" + Environment.ProcessPath?.Replace("/", "|").Replace("\\", "|"); // <-- Add this if you want multiple copies of the same app to have different configurations.
     Program.Tracker.Configure<Window>()
         .Id(w => w.Name, trackerNamespace)
         .Properties(w => new { w.WindowState, w.Position, w.Width, w.Height })

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ public MainWindow()
     {
         this.WindowState = WindowState.Normal;
     }
-    if (this.Position.X < 0 || this.Position.Y < 0)
+    if (this.Position.X < -1 || this.Position.Y < -1) // -1 is used by Windows11 when docking windows on the side.
     {
         this.Position = initialPosition;
     }

--- a/README.md
+++ b/README.md
@@ -156,6 +156,33 @@ protected override void OnLoad(EventArgs e)
 }
 ```
 
+#### Avalonia UI
+
+For [Avalonia UI](https://avaloniaui.net/) it is similar to WPF except that the screen information is available from the Window class instead of being static.
+
+``` C#
+// in the Program.cs
+public static Tracker Tracker = new Tracker();
+
+// in the Window constructor
+
+public MainWindow()
+{
+    InitializeComponent();
+#if DEBUG
+    this.AttachDevTools();
+#endif
+    var trackerNamespace = string.Join("|", Screens.All.Select(s => s.WorkingArea.Size.ToString()));
+    var trackerNamespace += Environment.ProcessPath; // <-- Add this if you want multiple copies of the same app to have different configurations.
+    Program.Tracker.Configure<Window>()
+        .Id(w => w.Name, trackerNamespace)
+        .Properties(w => new { w.WindowState, w.Position, w.Width, w.Height })
+        .PersistOn(nameof(Window.Closing))
+        .StopTrackingOn(nameof(Window.Closing));
+    Program.Tracker.Track(this);
+}
+```
+
 ## Which properties to track
 
 There are two methods (and several overloads) for telling Jot which properties of a given type to track. 


### PR DESCRIPTION
Avalonia is a popular UI framework that takes on after WPF and goes beyond having support for multiple platforms while giving the same development experience as WPF.

That is why I think it is relevant enough to have its own example here in `Jot`.